### PR TITLE
Fix query templates carrying pre-2.4.0 bugs to conform to TPC-DS 4.0.0 (q78 + 14 others)

### DIFF
--- a/00_compile_tpcds/query_templates/query24.tpl
+++ b/00_compile_tpcds/query_templates/query24.tpl
@@ -61,7 +61,8 @@ where ss_ticket_number = sr_ticket_number
   and ss_customer_sk = c_customer_sk
   and ss_item_sk = i_item_sk
   and ss_store_sk = s_store_sk
-  and c_birth_country = upper(ca_country)
+  and c_current_addr_sk = ca_address_sk
+  and c_birth_country <> upper(ca_country)
   and s_zip = ca_zip
 and s_market_id=[MARKET]
 group by c_last_name
@@ -85,6 +86,9 @@ group by c_last_name
         ,s_store_name
 having sum(netpaid) > (select 0.05*avg(netpaid)
                                  from ssales)
+order by c_last_name
+        ,c_first_name
+        ,s_store_name
 ;
 
 with ssales as
@@ -110,7 +114,8 @@ where ss_ticket_number = sr_ticket_number
   and ss_customer_sk = c_customer_sk
   and ss_item_sk = i_item_sk
   and ss_store_sk = s_store_sk
-  and c_birth_country = upper(ca_country)
+  and c_current_addr_sk = ca_address_sk
+  and c_birth_country <> upper(ca_country)
   and s_zip = ca_zip
   and s_market_id = [MARKET]
 group by c_last_name
@@ -134,6 +139,9 @@ group by c_last_name
         ,s_store_name
 having sum(netpaid) > (select 0.05*avg(netpaid)
                            from ssales)
+order by c_last_name
+        ,c_first_name
+        ,s_store_name
 ;
 
  

--- a/00_compile_tpcds/query_templates/query30.tpl
+++ b/00_compile_tpcds/query_templates/query30.tpl
@@ -50,7 +50,7 @@
          ,ca_state)
  [_LIMITA] select [_LIMITB] c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag
        ,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address
-       ,c_last_review_date,ctr_total_return
+       ,c_last_review_date_sk,ctr_total_return
  from customer_total_return ctr1
      ,customer_address
      ,customer
@@ -62,5 +62,5 @@
        and ctr1.ctr_customer_sk = c_customer_sk
  order by c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag
                   ,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address
-                  ,c_last_review_date,ctr_total_return
+                  ,c_last_review_date_sk,ctr_total_return
 [_LIMITC];

--- a/00_compile_tpcds/query_templates/query34.tpl
+++ b/00_compile_tpcds/query_templates/query34.tpl
@@ -33,7 +33,7 @@
 -- Contributors:
 -- 
  define BPONE= text({"1001-5000",1},{">10000",1},{"501-1000",1});
- define BPTWO= text({"0-500",1},{"unknown",1},{"5001-10000",1});
+ define BPTWO= text({"0-500",1},{"Unknown",1},{"5001-10000",1});
  define YEAR= random(1998, 2000, uniform);
  define COUNTYNUMBER=ulist(random(1, rowcount("active_counties", "store"), uniform), 8);
  define COUNTY_A=distmember(fips_county, [COUNTYNUMBER.1], 2);
@@ -73,6 +73,6 @@
     group by ss_ticket_number,ss_customer_sk) dn,customer
     where ss_customer_sk = c_customer_sk
       and cnt between 15 and 20
-    order by c_last_name,c_first_name,c_salutation,c_preferred_cust_flag desc
+    order by c_last_name,c_first_name,c_salutation,c_preferred_cust_flag desc, ss_ticket_number
  limit 100;
 

--- a/00_compile_tpcds/query_templates/query47.tpl
+++ b/00_compile_tpcds/query_templates/query47.tpl
@@ -35,8 +35,8 @@
  define YEAR=random(1999,2001,uniform);
  define _LIMIT=100;
  define SELECTONE= text({"v1.i_category",1},{"v1.i_brand",1},{"v1.i_category, v1.i_brand",1},{"v1.s_store_name",1},{"v1.s_company_name",1},{"v1.s_store_name, v1.s_company_name",1},{"v1.i_category, v1.i_brand, v1.s_store_name, v1.s_company_name",1}); 
- define SELECTTWO= text({",v1.d_year",1},{",v1.d_year, v1.d_moy",1}); 
-
+ define SELECTTWO= text({",v1.d_year",1},{",v1.d_year, v1.d_moy",1});
+ define ORDERBY= text({"avg_monthly_sales",1},{"sum_sales",1},{"psum",1},{"nsum",1});
 
  with v1 as(
  select i_category, i_brand,
@@ -84,6 +84,6 @@
  where  d_year = [YEAR] and    
         avg_monthly_sales > 0 and
         case when avg_monthly_sales > 0 then abs(sum_sales - avg_monthly_sales) / avg_monthly_sales else null end > 0.1
- order by sum_sales - avg_monthly_sales, 3
+ order by sum_sales - avg_monthly_sales, [ORDERBY]
  [_LIMITC];
 

--- a/00_compile_tpcds/query_templates/query49.tpl
+++ b/00_compile_tpcds/query_templates/query49.tpl
@@ -158,7 +158,7 @@
  or 
  store.currency_rank <= 10
  )
- order by 1,4,5
+ order by 1,4,5,2
  [_LIMITC];
  
 

--- a/00_compile_tpcds/query_templates/query56.tpl
+++ b/00_compile_tpcds/query_templates/query56.tpl
@@ -101,7 +101,8 @@ where i_color in ('[COLOR.1]','[COLOR.2]','[COLOR.3]'))
         union all
         select * from ws) tmp1
  group by i_item_id
- order by total_sales
+ order by total_sales,
+          i_item_id
  [_LIMITC];
  
 

--- a/00_compile_tpcds/query_templates/query57.tpl
+++ b/00_compile_tpcds/query_templates/query57.tpl
@@ -34,7 +34,8 @@
 -- 
  define YEAR=random(1999,2001,uniform);
  define SELECTONE= text({"v1.i_category",1},{"v1.i_brand",1},{"v1.i_category, v1.i_brand",1},{"v1.cc_name",1},{"v1.i_category, v1.i_brand, v1.cc_name",1}); 
- define SELECTTWO= text({",v1.d_year",1},{",v1.d_year, v1.d_moy",1}); 
+ define SELECTTWO= text({",v1.d_year",1},{",v1.d_year, v1.d_moy",1});
+ define ORDERBY= text({"avg_monthly_sales",1},{"sum_sales",1},{"psum",1},{"nsum",1});
 
  define _LIMIT=100;
 
@@ -81,6 +82,6 @@
  where  d_year = [YEAR] and
         avg_monthly_sales > 0 and
         case when avg_monthly_sales > 0 then abs(sum_sales - avg_monthly_sales) / avg_monthly_sales else null end > 0.1
- order by sum_sales - avg_monthly_sales, 3
+ order by sum_sales - avg_monthly_sales, [ORDERBY]
  [_LIMITC];
 

--- a/00_compile_tpcds/query_templates/query6.tpl
+++ b/00_compile_tpcds/query_templates/query6.tpl
@@ -57,6 +57,6 @@
  	     where j.i_category = i.i_category)
  group by a.ca_state
  having count(*) >= 10
- order by cnt 
+ order by cnt, a.ca_state
  [_LIMITC];
 

--- a/00_compile_tpcds/query_templates/query64.tpl
+++ b/00_compile_tpcds/query_templates/query64.tpl
@@ -153,4 +153,6 @@ where cs1.item_sk=cs2.item_sk and
 order by cs1.product_name
        ,cs1.store_name
        ,cs2.cnt
+       ,cs1.s1
+       ,cs2.s1
 limit 100;

--- a/00_compile_tpcds/query_templates/query66.tpl
+++ b/00_compile_tpcds/query_templates/query66.tpl
@@ -219,7 +219,7 @@
  	,sum(case when d_moy = 9 
  		then [NETTWO] * cs_quantity else 0 end) as sep_net
  	,sum(case when d_moy = 10 
- 		then [NETTWo] * cs_quantity else 0 end) as oct_net
+ 		then [NETTWO] * cs_quantity else 0 end) as oct_net
  	,sum(case when d_moy = 11
  		then [NETTWO] * cs_quantity else 0 end) as nov_net
  	,sum(case when d_moy = 12

--- a/00_compile_tpcds/query_templates/query73.tpl
+++ b/00_compile_tpcds/query_templates/query73.tpl
@@ -33,7 +33,7 @@
 -- Contributors:
 -- 
  define BPONE= text({"1001-5000",1},{">10000",1},{"501-1000",1});
- define BPTWO= text({"0-500",1},{"unknown",1},{"5001-10000",1});
+ define BPTWO= text({"0-500",1},{"Unknown",1},{"5001-10000",1});
  define YEAR= random(1998, 2000, uniform);
  define COUNTYNUMBER=ulist(random(1, rowcount("active_counties", "store"), uniform),8);
  define COUNTY_A=distmember(fips_county, [COUNTYNUMBER.1], 2);

--- a/00_compile_tpcds/query_templates/query75.tpl
+++ b/00_compile_tpcds/query_templates/query75.tpl
@@ -103,5 +103,5 @@ WITH all_sales AS (
    AND curr_yr.d_year=[YEAR]
    AND prev_yr.d_year=[YEAR]-1
    AND CAST(curr_yr.sales_cnt AS DECIMAL(17,2))/CAST(prev_yr.sales_cnt AS DECIMAL(17,2))<0.9
- ORDER BY sales_cnt_diff
+ ORDER BY sales_cnt_diff,sales_amt_diff
  [_LIMITC];

--- a/00_compile_tpcds/query_templates/query78.tpl
+++ b/00_compile_tpcds/query_templates/query78.tpl
@@ -75,20 +75,20 @@ ss as
    )
 [_LIMITA] select [_LIMITB]
 [SELECTONE],
-round(ss_qty/(coalesce(ws_qty+cs_qty,1)),2) ratio,
+round(ss_qty/(coalesce(ws_qty,0)+coalesce(cs_qty,0)),2) ratio,
 ss_qty store_qty, ss_wc store_wholesale_cost, ss_sp store_sales_price,
 coalesce(ws_qty,0)+coalesce(cs_qty,0) other_chan_qty,
 coalesce(ws_wc,0)+coalesce(cs_wc,0) other_chan_wholesale_cost,
 coalesce(ws_sp,0)+coalesce(cs_sp,0) other_chan_sales_price
 from ss
 left join ws on (ws_sold_year=ss_sold_year and ws_item_sk=ss_item_sk and ws_customer_sk=ss_customer_sk)
-left join cs on (cs_sold_year=ss_sold_year and cs_item_sk=cs_item_sk and cs_customer_sk=ss_customer_sk)
-where coalesce(ws_qty,0)>0 and coalesce(cs_qty, 0)>0 and ss_sold_year=[YEAR]
+left join cs on (cs_sold_year=ss_sold_year and cs_item_sk=ss_item_sk and cs_customer_sk=ss_customer_sk)
+where (coalesce(ws_qty,0)>0 or coalesce(cs_qty, 0)>0) and ss_sold_year=[YEAR]
 order by 
   [SELECTONE],
   ss_qty desc, ss_wc desc, ss_sp desc,
   other_chan_qty,
   other_chan_wholesale_cost,
   other_chan_sales_price,
-  round(ss_qty/(coalesce(ws_qty+cs_qty,1)),2)
+  ratio
 [_LIMITC];

--- a/00_compile_tpcds/query_templates/query84.tpl
+++ b/00_compile_tpcds/query_templates/query84.tpl
@@ -37,7 +37,7 @@
  define _LIMIT=100;
  
  [_LIMITA] select [_LIMITB] c_customer_id as customer_id
-       ,c_last_name || ', ' || c_first_name as customername
+       , coalesce(c_last_name,'') || ', ' || coalesce(c_first_name,'') as customername
  from customer
      ,customer_address
      ,customer_demographics

--- a/00_compile_tpcds/query_templates/query85.tpl
+++ b/00_compile_tpcds/query_templates/query85.tpl
@@ -95,7 +95,7 @@
     (
      ca_country = 'United States'
      and
-     ca_state in ('[STATE.1]', '[STATE.2]', '[STATE.3 ]')
+     ca_state in ('[STATE.1]', '[STATE.2]', '[STATE.3]')
      and ws_net_profit between 100 and 200  
     )
     or


### PR DESCRIPTION
## What

Fixes #47. The v2.0 upgrade (PR #35) refreshed the `dsqgen`/`dsdgen` binaries to TPC-DS **4.0.0** but never re-synced `00_compile_tpcds/query_templates/`, so several templates still carried **pre-2.4.0** logic/token/ordering bugs — the generated queries did not conform to 4.0.0.

This ports the 4.0.0 corrections into the **existing dialect-adapted templates**, touching only the offending lines. The intended Greenplum/Cloudberry adaptations are preserved (interval syntax `'30 days'::interval`, derived-table aliases `) x` / `) as sub`, `decimal`/`dec`, the custom `cloudberry.tpl`, and the toolkit's `limit 100` caps). Nothing was blind-overwritten from the raw 4.0.0 directory.

## Changes (15 templates)

**A — wrong SQL logic (results could be incorrect)**
| query | fix |
|---|---|
| q78 | `cs_item_sk=cs_item_sk` self-join → `cs_item_sk=ss_item_sk`; restore 4.0.0 `ratio` divisor `coalesce(ws_qty,0)+coalesce(cs_qty,0)`; `WHERE … and …` → `or`; `ORDER BY … ratio` column ref (FogBugz 1654 / 2037) |
| q24 | add missing `c_current_addr_sk = ca_address_sk` join + invert predicate to `c_birth_country <> upper(ca_country)`; restore the dropped `ORDER BY` in both blocks |
| q30 | old column `c_last_review_date` → `c_last_review_date_sk` |
| q84 | add 4.0.0 `coalesce(…,'')` null-safety around `customername` |

**B — broken substitution tokens (generation picked wrong/blank value)**
| query | fix |
|---|---|
| q66 | `[NETTWo]` → `[NETTWO]` |
| q85 | `'[STATE.3 ]'` → `'[STATE.3]'` (stray space) |
| q34, q73 | dist value `unknown` → `Unknown` |

**C — missing ORDER BY tiebreakers / parameterized ordering (non-deterministic, won't match 4.0.0 answer sets)**
| query | fix |
|---|---|
| q6  | add `a.ca_state` |
| q34 | add `ss_ticket_number` |
| q49 | add the `item` tiebreaker (`order by 1,4,5` → `1,4,5,2`) |
| q56 | add `i_item_id` |
| q64 | add `cs1.s1, cs2.s1` |
| q75 | add `sales_amt_diff` |
| q47, q57 | restore `define ORDERBY=text(...)` + the `[ORDERBY]` substitution (deployed had hard-coded positional `3`) |

> Note: q49 and q24's missing `ORDER BY` were not in the original issue body — they were found during a full re-diff and added in [this follow-up comment](https://github.com/cloudberry-contrib/TPC-DS-Toolkit/issues/47#issuecomment-4655383954).

## Verification

All 15 patched templates were generated with the toolkit's own invocation (`dsqgen -dialect cloudberry -distributions tpcds.idx`) — every one produces valid SQL, and the restored/fixed substitution tokens resolve correctly in the output:

- q78 → `cs_item_sk=ss_item_sk`, `coalesce(ws_qty,0)+coalesce(cs_qty,0)`, `where (… or …)`, `order by … ratio`
- q47 / q57 → `order by sum_sales - avg_monthly_sales, avg_monthly_sales` (token resolves, not literal `3`)
- q66 → `oct_net` now uses the same `[NETTWO]`-driven expression as its sibling months
- q85 → `ca_state in ('TX', 'KY', 'CO')` (no stray space)

## Scope / not in this PR

- The remaining ~29 differing templates are confirmed to be **intended dialect + cosmetics** only (no logic bugs).
- Minor divergences left as-is and noted in the issue thread: q61 `decimal(15,4)`→`decimal(16,4)` (numerically harmless) and the q34/q64/q71 `limit 100` (a deliberate toolkit cap, not a 4.0.0 element).
- The issue also suggests having `make_tpc()` reconcile templates against the bundled 4.0.0 source on each build to prevent future drift — left as a separate follow-up.
