### PR TITLE
Fix q30 regression from #48: c_last_review_date_sk → c_last_review_date

### DIFF
--- a/00_compile_tpcds/query_templates/query30.tpl
+++ b/00_compile_tpcds/query_templates/query30.tpl
@@ -50,7 +50,7 @@
          ,ca_state)
  [_LIMITA] select [_LIMITB] c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag
        ,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address
-       ,c_last_review_date_sk,ctr_total_return
+       ,c_last_review_date,ctr_total_return
  from customer_total_return ctr1
      ,customer_address
      ,customer
@@ -62,5 +62,5 @@
        and ctr1.ctr_customer_sk = c_customer_sk
  order by c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag
                   ,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address
-                  ,c_last_review_date_sk,ctr_total_return
+                  ,c_last_review_date,ctr_total_return
 [_LIMITC];


### PR DESCRIPTION
PR #48 changed `query30.tpl` to use `c_last_review_date_sk`, but this toolkit's `customer` DDL has no such column.

## The bug
`03_ddl/005.gpdb.customer.sql:19` defines the column as `c_last_review_date integer` — there is **no** `c_last_review_date_sk` in the toolkit's schema. `query30.tpl` originally matched this. #48 changed it to `c_last_review_date_sk` to "conform to TPC-DS 4.0.0", which made the generated query30 reference a non-existent column → it would fail at execution with `column "c_last_review_date_sk" does not exist`.

## Why #48 did not catch it
#48 verified only that templates **generate** with `dsqgen -dialect cloudberry`. `dsqgen` does token/parameter substitution and does **not** validate column names against the database, so a wrong-but-syntactically-fine column name passes generation and only fails when the generated SQL is actually run.

## Fix
Revert the two `c_last_review_date_sk` occurrences in `query30.tpl` back to `c_last_review_date` (lines 53 and 65).

## Verification (execution layer, against a loaded TPC-DS customer table)
- **new** (`c_last_review_date`): generated query30 `EXPLAIN`s successfully (full plan, references `customer.c_last_review_date`)
- **old** (`c_last_review_date_sk`): `ERROR: column "c_last_review_date_sk" does not exist` — DB even hints `Perhaps you meant customer.c_last_review_date`

This restores `query30.tpl` to the exact pre-#48 blob (`2977a73`) for these lines.